### PR TITLE
Fixed fail reports by adding missing prereqs.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,8 @@ copyright_holder = Fayland Lam
 [@FAYLAND]
 
 [Prereqs]
+Moose = 0
+Moose::Autobox = 0
 Dist::Zilla = 5
 Dist::Zilla::Plugin::PodWeaver = 3.092971
 Dist::Zilla::Plugin::PerlTidy = 0.06


### PR DESCRIPTION
Hi @fayland 

Please review the PR.
Following FAIL reports are because of missing prereqs Moose and Moose::Autobox as reported by CPANTS.

https://cpants.cpanauthors.org/release/FAYLAND/Dist-Zilla-PluginBundle-FAYLAND-0.14

https://www.cpantesters.org/distro/D/Dist-Zilla-PluginBundle-FAYLAND.html?oncpan=1&distmat=1&version=0.14&grade=3

Many Thanks.
Best Regards,
Mohammad S Anwar